### PR TITLE
Validation

### DIFF
--- a/Block/Adminhtml/Brands/Grid/Renderer/BrandIcon.php
+++ b/Block/Adminhtml/Brands/Grid/Renderer/BrandIcon.php
@@ -17,7 +17,7 @@ class BrandIcon extends \MageSuite\BrandManagement\Block\Adminhtml\Brands\Grid\R
             return '';
         }
 
-        $iconPath = $this->filesystem->getDirectoryRead(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA)->getAbsolutePath() . 'brands/' . $brandData->getBrandIcon();
+        $iconPath = $this->filesystem->getDirectoryRead(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA)->getAbsolutePath() . 'brands/icon/' . ltrim($brandData->getBrandIcon(), '/');
 
         if (!file_exists($iconPath)) {
             return '';

--- a/Controller/Adminhtml/Brand/Upload.php
+++ b/Controller/Adminhtml/Brand/Upload.php
@@ -2,7 +2,7 @@
 
 namespace MageSuite\BrandManagement\Controller\Adminhtml\Brand;
 
-class Upload extends \Magento\Framework\App\Action\Action
+class Upload extends \Magento\Backend\App\Action
 {
     /**
      * @var \MageSuite\BrandManagement\Model\Brands\Processor\UploadFactory
@@ -17,10 +17,9 @@ class Upload extends \Magento\Framework\App\Action\Action
     public function __construct(
         \Magento\Backend\App\Action\Context $context,
         \MageSuite\BrandManagement\Model\Brands\Processor\UploadFactory $uploadProcessor
-    )
-    {
-        $this->uploadProcessor = $uploadProcessor;
+    ) {
         parent::__construct($context);
+        $this->uploadProcessor = $uploadProcessor;
     }
 
     /**
@@ -28,12 +27,7 @@ class Upload extends \Magento\Framework\App\Action\Action
      */
     public function execute()
     {
-        try {
-            $result = $this->uploadProcessor->create()->processUpload();
-        } catch (\Exception $e)
-        {
-            $result = ['error' => $e->getMessage(), 'errorcode' => $e->getCode()];
-        }
+        $result = $this->uploadProcessor->create()->processUpload();
         return $this->resultFactory->create(\Magento\Framework\Controller\ResultFactory::TYPE_JSON)->setData($result);
     }
 

--- a/Model/Brands.php
+++ b/Model/Brands.php
@@ -283,7 +283,7 @@ class Brands extends \Magento\Catalog\Model\AbstractModel implements \MageSuite\
                 ->getStore()
                 ->getBaseUrl(
                     \Magento\Framework\UrlInterface::URL_TYPE_MEDIA
-                ) . 'brands/' . $icon;
+                ) . 'brands/icon/' . ltrim($icon, '/');
     }
 
 
@@ -302,7 +302,7 @@ class Brands extends \Magento\Catalog\Model\AbstractModel implements \MageSuite\
                 ->getStore()
                 ->getBaseUrl(
                     \Magento\Framework\UrlInterface::URL_TYPE_MEDIA
-                ) . 'brands/' . $icon;
+                ) . 'brands/additional_icon/' . ltrim($icon, '/');
     }
 
     public function getBrandUrl()

--- a/Model/Brands/Processor/Save.php
+++ b/Model/Brands/Processor/Save.php
@@ -23,18 +23,24 @@ class Save
      * @var \Magento\Framework\DataObjectFactory
      */
     private $dataObjectFactory;
+    /**
+     * @var \MageSuite\BrandManagement\Model\Brands\Processor\UploadFactory
+     */
+    protected $uploadProcessor;
 
     public function __construct(
         \MageSuite\BrandManagement\Model\BrandsFactory $brandsFactory,
         \MageSuite\BrandManagement\Api\BrandsRepositoryInterface $brandsRepository,
         \Magento\Framework\Event\Manager $eventManager,
-        \Magento\Framework\DataObjectFactory $dataObjectFactory
+        \Magento\Framework\DataObjectFactory $dataObjectFactory,
+        \MageSuite\BrandManagement\Model\Brands\Processor\UploadFactory $uploadProcessor
     )
     {
         $this->brandsFactory = $brandsFactory;
         $this->brandsRepository = $brandsRepository;
         $this->eventManager = $eventManager;
         $this->dataObjectFactory = $dataObjectFactory;
+        $this->uploadProcessor = $uploadProcessor;
     }
 
     public function processSave($params) {
@@ -62,10 +68,11 @@ class Save
 
         if(isset($params['brand_icon'])) {
             if (is_array($params['brand_icon'])) {
-                $imagePath = $params['brand_icon'][0]['name'];
+                $imagePath = $params['brand_icon'][0]['file'];
             } else {
                 $imagePath = $params['brand_icon'];
             }
+            $this->uploadProcessor->create()->moveFileFromTmp($imagePath, 'brand_icon');
         }
         if($imagePath){
             $brand->setBrandIcon($imagePath);
@@ -77,10 +84,11 @@ class Save
 
         if(isset($params['brand_additional_icon'])) {
             if (is_array($params['brand_additional_icon'])) {
-                $imageAdditionalPath = $params['brand_additional_icon'][0]['name'];
+                $imageAdditionalPath = $params['brand_additional_icon'][0]['file'];
             } else {
                 $imageAdditionalPath = $params['brand_additional_icon'];
             }
+            $this->uploadProcessor->create()->moveFileFromTmp($imageAdditionalPath, 'brand_additional_icon');
         }
         if($imageAdditionalPath){
             $brand->setBrandAdditionalIcon($imageAdditionalPath);
@@ -118,12 +126,12 @@ class Save
             }
 
             if($field == 'brand_icon'){
-                $matchedParams[$field] = $params['brand_icon'][0]['name'];
+                $matchedParams[$field] = $params['brand_icon'][0]['file'];
                 continue;
             }
 
             if($field == 'brand_additional_icon'){
-                $matchedParams[$field] = $params['brand_additional_icon'][0]['name'];
+                $matchedParams[$field] = $params['brand_additional_icon'][0]['file'];
                 continue;
             }
 

--- a/Model/Brands/Processor/Upload.php
+++ b/Model/Brands/Processor/Upload.php
@@ -1,151 +1,325 @@
 <?php
 namespace MageSuite\BrandManagement\Model\Brands\Processor;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Api\ImageContentValidatorInterface;
+use Magento\Framework\Api\Uploader;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\MediaStorage\Model\File\UploaderFactory;
+use Magento\MediaStorage\Helper\File\Storage\Database;
+use Psr\Log\LoggerInterface;
+
 class Upload
 {
     protected $mimeTypeExtensionMap = [
-        'image/jpg' => 'jpg',
-        'image/jpeg' => 'jpg',
-        'image/gif' => 'gif',
-        'image/png' => 'png',
+        'image/jpg'     => 'jpg',
+        'image/jpeg'    => 'jpeg',
+        'image/gif'     => 'gif',
+        'image/png'     => 'png',
+        'image/svg+xml' => 'svg'
     ];
-    /**
-     * @var \Magento\Framework\Api\ImageContentValidatorInterface
-     */
-    protected $imageContentValidator;
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
-    /**
-     * @var \Magento\Framework\App\Filesystem\DirectoryList
-     */
-    protected $directoryList;
+
     /**
      * @var \Magento\Framework\Filesystem
      */
     protected $filesystem;
+
+    /**
+     * Media Directory object (writable)
+     *
+     * @var \Magento\Framework\Filesystem\Directory\WriteInterface
+     */
+    protected $mediaDirectory;
+
+    /**
+     * System Tmp Directory object (writable)
+     *
+     * @var \Magento\Framework\Filesystem\Directory\WriteInterface
+     */
+    protected $sysTmpDirectory;
+
+    /**
+     * @var \Magento\Framework\Api\ImageContentValidatorInterface
+     */
+    protected $imageContentValidator;
+
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
     protected $storeManager;
+
     /**
-     * @var \MageSuite\BrandManagement\Model\BrandsFactory
+     * @var \Psr\Log\LoggerInterface
      */
-    protected $brand;
+    protected $logger;
+
     /**
      * @var \Magento\Framework\Api\Uploader
      */
     protected $uploader;
 
+    /**
+     * @var \Magento\MediaStorage\Model\File\UploaderFactory
+     */
+    protected $uploaderFactory;
+
+    /**
+     * @var \Magento\MediaStorage\Helper\File\Storage\Database
+     */
+    protected $dbFileStorage;
+
+    const FILE_DIR = 'brands';
+
+    const MAX_FILE_SIZE = 1024;
+
+    /**
+     * @param Filesystem $filesystem
+     * @param ImageContentValidatorInterface $imageContentValidator
+     * @param StoreManagerInterface $storeManager
+     * @param LoggerInterface $logger
+     * @param Uploader $uploader
+     * @param UploaderFactory $uploaderFactory
+     * @param Database $dbFileStorage
+     */
     public function __construct(
-        \Magento\Framework\App\Filesystem\DirectoryList $directoryList,
-        \Magento\Framework\Filesystem $filesystem,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \MageSuite\BrandManagement\Model\BrandsFactory $brand,
-        \Magento\Framework\Api\ImageContentValidatorInterface $imageContentValidator,
-        \Psr\Log\LoggerInterface $logger,
-        \Magento\Framework\Api\Uploader $uploader
-    )
-    {
-        $this->directoryList = $directoryList;
+        Filesystem $filesystem,
+        ImageContentValidatorInterface $imageContentValidator,
+        StoreManagerInterface $storeManager,
+        LoggerInterface $logger,
+        Uploader $uploader,
+        UploaderFactory $uploaderFactory,
+        Database $dbFileStorage
+    ) {
+        $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::MEDIA);
+        $this->sysTmpDirectory = $filesystem->getDirectoryWrite(DirectoryList::SYS_TMP);
         $this->filesystem = $filesystem;
-        $this->storeManager = $storeManager;
-        $this->brand = $brand;
         $this->imageContentValidator = $imageContentValidator;
+        $this->storeManager = $storeManager;
         $this->logger = $logger;
         $this->uploader = $uploader;
+        $this->uploaderFactory = $uploaderFactory;
+        $this->dbFileStorage = $dbFileStorage;
     }
 
+    /**
+     * Save image
+     *
+     * @param array|null $imageData
+     * @return array
+     * @throws LocalizedException
+     */
     public function processUpload($imageData = null)
     {
-        if($imageData) {
-            $fileAttributes = $this->prepareUploadBase64Encoded($imageData);
-        } else {
-            $fileAttributes = $this->prepareUploadImage();
-        }
-
         try {
-            $this->uploader->processFileAttributes($fileAttributes);
-            $this->uploader->setFilesDispersion(false);
-            $this->uploader->setFilenamesCaseSensitivity(false);
-            $this->uploader->setAllowRenameFiles(true);
-            $destinationFolder = $this->filesystem->getDirectoryRead(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA)
-                ->getAbsolutePath('brands/');
-            $result = $this->uploader->save($destinationFolder, $fileAttributes['name']);
-
-            if($imageData){
-                return $this->uploader->getUploadedFileName();
+            if ($imageData) {
+                // Process file from api
+                $fileAttributes = $this->prepareUploadBase64Encoded($imageData['imageData']);
+                $fileId = $imageData['type'];
+                $uploader = $this->uploader->processFileAttributes($fileAttributes);
             } else {
-                $imagePath = $this->uploader->getUploadedFileName();
-                if (!$result) {
-                    throw new \Magento\Framework\Exception\LocalizedException(
-                        __('File can not be saved to the destination folder.')
-                    );
-                }
+                // Process file from upload
+                $fileId = key($_FILES);
+                $uploader = $this->uploaderFactory->create(['fileId' => $fileId]);
+            }
 
-                $result['tmp_name'] = str_replace('\\', '/', $result['tmp_name']);
-                $result['path'] = str_replace('\\', '/', $result['path']);
+            $path = $this->getPathForField($fileId);
+            $basePath = self::FILE_DIR . '/' . $path;
+            $tmpBasePath = 'tmp/' . $basePath;
 
-                $result['url'] = $this->brand->create()->getBrandIconUrl($imagePath);
+            $destination = $this->getAbsoluteMediaPath($tmpBasePath);
 
-                $result['name'] = $result['file'];
+            $uploader->setAllowRenameFiles(true);
+            $uploader->setFilesDispersion(true);
+            $uploader->setAllowedExtensions($this->getAllowedExtensions());
+            $uploader->addValidateCallback('size', $this, 'validateMaxSize');
 
-                return $result;
+            if ($imageData) {
+                $result = $uploader->save($destination, $fileAttributes['name']);
+            } else {
+                $result = $uploader->save($destination);
+            }
+            if (!$result) {
+                throw new LocalizedException(__('File can not be saved to the destination folder.'));
+            }
+
+            $result['tmp_name'] = $this->prepareFile($result['tmp_name']);
+            $result['path'] = $this->prepareFile($result['path']);
+            $result['url'] = $this->getTmpMediaUrl($result['file'], $tmpBasePath);
+            $result['name'] = pathinfo($result['file'], PATHINFO_BASENAME);
+
+            if (isset($result['file'])) {
+                $relativePath = $this->getFilePath($tmpBasePath, $result['file']);
+                $this->dbFileStorage->saveFile($relativePath);
             }
         } catch (\Exception $e) {
-            
             $this->logger->critical($e);
+            $result = ['error' => $e->getMessage(), 'errorcode' => $e->getCode()];
         }
 
-        return false;
+        return $result;
     }
 
-    public function prepareUploadImage()
+    /**
+     * Move image from tmp directory
+     */
+    public function moveFileFromTmp($imageName, $type)
     {
-        if(!isset($_FILES) && !$_FILES['brand_icon']['name']) {
-            $result = ['error' => __('Image file has been not uploaded'), 'errorcode' => __('Image file has been not uploaded')];
-            return $result;
+        $path = $this->getPathForField($type);
+        $basePath = self::FILE_DIR . '/' . $path;
+        $tmpBasePath = 'tmp/' . $basePath;
+
+        $imageBasePath = $this->getFilePath($basePath, $imageName);
+        $imageTmpBasePath = $this->getFilePath($tmpBasePath, $imageName);
+
+        try {
+            $this->dbFileStorage->copyFile(
+                $imageTmpBasePath,
+                $imageBasePath
+            );
+            $this->mediaDirectory->renameFile(
+                $imageTmpBasePath,
+                $imageBasePath
+            );
+        } catch (\Exception $e) {
+            $this->logger->critical($e);
+            throw new LocalizedException(__('Something went wrong while saving the file(s).'));
         }
 
-        return [
-            'tmp_name' => $_FILES['brand_icon']['tmp_name'],
-            'name' => $_FILES['brand_icon']['name']
-        ];
+        return $imageName;
     }
 
+    /**
+     * Generate uploaded file from base 64 encoded image
+     *
+     * @param $imageData
+     * @return array
+     */
     public function prepareUploadBase64Encoded($imageData)
     {
         if (!$this->imageContentValidator->isValid($imageData)) {
-            throw new \Magento\Framework\Exception\InputException(new \Magento\Framework\Phrase('The image content is invalid. Verify the content and try again.'));
+            throw new InputException(new \Magento\Framework\Phrase('The image content is invalid. Verify the content and try again.'));
         }
 
         $fileContent = @base64_decode($imageData->getBase64EncodedData(), true);
-        $tmpDirectory = $this->filesystem->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::SYS_TMP);
         $fileName = $this->getFileName($imageData);
         $tmpFileName = substr(md5(rand()), 0, 7) . '.' . $fileName;
-        $tmpDirectory->writeFile($tmpFileName, $fileContent);
+        $this->sysTmpDirectory->writeFile($tmpFileName, $fileContent);
+        $absTmpFileName = $this->sysTmpDirectory->getAbsolutePath() . $tmpFileName;
 
         return [
-            'tmp_name' => $tmpDirectory->getAbsolutePath() . $tmpFileName,
-            'name' => $fileName
+            'tmp_name' => $absTmpFileName,
+            'name' => $fileName,
+            'type' => $imageData->getType(),
+            'size' => filesize($absTmpFileName)
         ];
     }
 
+    /**
+     * Get filename with extension from image data
+     *
+     * @param array $imageContent
+     * @return string
+     * @throws InputException
+     */
     protected function getFileName($imageContent)
     {
         $fileName = $imageContent->getName();
         if (!pathinfo($fileName, PATHINFO_EXTENSION)) {
             if (!$imageContent->getType() || !$this->getMimeTypeExtension($imageContent->getType())) {
-                throw new \Magento\Framework\Exception\InputException(new \Magento\Framework\Phrase('Cannot recognize image extension.'));
+                throw new InputException(new \Magento\Framework\Phrase('Cannot recognize image extension.'));
             }
             $fileName .= '.' . $this->getMimeTypeExtension($imageContent->getType());
         }
         return $fileName;
     }
 
+    protected function getFilePath($path, $file)
+    {
+        return rtrim($path, '/') . '/' . ltrim($file, '/');
+    }
+
+    /**
+     * Get extension by mimeType
+     *
+     * @param string $mimeType
+     * @return string
+     */
     protected function getMimeTypeExtension($mimeType)
     {
         return $this->mimeTypeExtensionMap[$mimeType] ?? '';
+    }
+
+    /**
+     * Retrieve absolute temp media path
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function getAbsoluteMediaPath($path)
+    {
+        return $this->mediaDirectory->getAbsolutePath($path);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getAllowedExtensions()
+    {
+        return array_values($this->mimeTypeExtensionMap);
+    }
+
+    /**
+     * @param string $fileId
+     * @return string
+     */
+    protected function getPathForField($type)
+    {
+        return str_replace('brand_', '', $type);
+    }
+
+    /**
+     * Validation callback for checking max file size
+     *
+     * @param  string $filePath Path to temporary uploaded file
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function validateMaxSize($filePath)
+    {
+        $directory = $this->filesystem->getDirectoryRead(DirectoryList::SYS_TMP);
+        if ($directory->stat($directory->getRelativePath($filePath))['size'] > self::MAX_FILE_SIZE * 1024) {
+            throw new LocalizedException(__(
+                'The file you\'re uploading exceeds the server size limit of %1 kilobytes.',
+                self::MAX_FILE_SIZE
+            ));
+        }
+    }
+
+    /**
+     * Retrieve temp media url
+     *
+     * @param string $file
+     * @param string $path
+     * @return string
+     */
+    protected function getTmpMediaUrl($file, $path)
+    {
+        return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA)
+            . $this->getFilePath($path, $this->prepareFile($file));
+    }
+
+    /**
+     * Prepare file
+     *
+     * @param string $file
+     * @return string
+     */
+    protected function prepareFile($file)
+    {
+        return str_replace('\\', '/', $file);
     }
 }

--- a/Model/BrandsRepository.php
+++ b/Model/BrandsRepository.php
@@ -123,7 +123,7 @@ class BrandsRepository implements \MageSuite\BrandManagement\Api\BrandsRepositor
                 }
                 $this->brandsResource->updateAttribute($brand, $attr, $value, $brand->getStoreId());
             }
-            
+
             $this->brandsResource->removeAttribute($brand, $attributesToRemove);
             $brand->afterSave();
         } catch (\Exception $e) {
@@ -195,11 +195,19 @@ class BrandsRepository implements \MageSuite\BrandManagement\Api\BrandsRepositor
             $uploader = $this->uploadFactory->create();
 
             if($brand->getBrandIconEncodedData()) {
-                $brand->setBrandIcon($uploader->processUpload($brand->getBrandIconEncodedData()));
+                $data = [
+                    'imageData' => $brand->getBrandIconEncodedData(),
+                    'type' => 'brand_icon'
+                ];
+                $brand->setBrandIcon($uploader->processUpload($data));
             }
 
             if($brand->getBrandAdditionalIconEncodedData()) {
-                $brand->setBrandAdditionalIcon($uploader->processUpload($brand->getBrandAdditionalIconEncodedData()));
+                $data = [
+                    'imageData' => $brand->getBrandAdditionalIconEncodedData(),
+                    'type' => 'brand_additional_icon'
+                ];
+                $brand->setBrandAdditionalIcon($uploader->processUpload($data));
             }
 
             $this->brandParamsValidator->validateParams($brand);

--- a/Validator/ImageContentValidator.php
+++ b/Validator/ImageContentValidator.php
@@ -21,6 +21,7 @@ class ImageContentValidator extends Validator
         'image/gif',
         'image/png',
         'image/svg+xml',
+        'image/svg',
     ];
 
     /**
@@ -59,7 +60,7 @@ class ImageContentValidator extends Validator
             }
             $sourceMimeType = $imageProperties['mime'];
         } else {
-            $sourceMimeType = 'image/svg+xml';
+            $sourceMimeType = $imageContent->getType();
         }
 
         if ($sourceMimeType != $imageContent->getType() || !$this->isMimeTypeValid($sourceMimeType)) {
@@ -85,7 +86,8 @@ class ImageContentValidator extends Validator
         $temp = tempnam(sys_get_temp_dir(), 'TMP_');
         file_put_contents($temp, $fileContent);
 
-        return 'image/svg+xml' === mime_content_type($temp);
+        $mt = mime_content_type($temp);
+        return 'image/svg+xml' === $mt || 'image/svg' === $mt;
     }
 
 }

--- a/Validator/ImageContentValidator.php
+++ b/Validator/ImageContentValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace MageSuite\BrandManagement\Validator;
+
+use Magento\Framework\Api\Data\ImageContentInterface;
+use Magento\Framework\Api\ImageContentValidator as Validator;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Phrase;
+
+/**
+ * Class for Image content validation
+ */
+class ImageContentValidator extends Validator
+{
+    /**
+     * @var array
+     */
+    private $defaultMimeTypes = [
+        'image/jpg',
+        'image/jpeg',
+        'image/gif',
+        'image/png',
+        'image/svg+xml',
+    ];
+
+    /**
+     * @var array
+     */
+    private $allowedMimeTypes;
+
+    /**
+     * @param  array  $allowedMimeTypes
+     */
+    public function __construct(
+        array $allowedMimeTypes = []
+    ) {
+        $this->allowedMimeTypes = array_merge($this->defaultMimeTypes, $allowedMimeTypes);
+        parent::__construct($this->allowedMimeTypes);
+    }
+
+    /**
+     * Check if gallery entry content is valid
+     *
+     * @param  ImageContentInterface  $imageContent
+     * @return bool
+     * @throws InputException
+     */
+    public function isValid(ImageContentInterface $imageContent)
+    {
+        $fileContent = @base64_decode($imageContent->getBase64EncodedData(), true);
+        if (empty($fileContent)) {
+            throw new InputException(new Phrase('The image content must be valid base64 encoded data.'));
+        }
+
+        if (!$this->isSvg($fileContent)) {
+            $imageProperties = @getimagesizefromstring($fileContent);
+            if (empty($imageProperties)) {
+                throw new InputException(new Phrase('The image content must be valid base64 encoded data.'));
+            }
+            $sourceMimeType = $imageProperties['mime'];
+        } else {
+            $sourceMimeType = 'image/svg+xml';
+        }
+
+        if ($sourceMimeType != $imageContent->getType() || !$this->isMimeTypeValid($sourceMimeType)) {
+            throw new InputException(new Phrase('The image MIME type is not valid or not supported.'));
+        }
+
+        if (!$this->isNameValid($imageContent->getName())) {
+            throw new InputException(new Phrase('Provided image name contains forbidden characters.'));
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if file content is svg
+     *
+     * @param  string  $fileContent
+     * @return bool
+     */
+    public function isSvg($fileContent)
+    {
+        // TODO make it more elegant
+        $temp = tempnam(sys_get_temp_dir(), 'TMP_');
+        file_put_contents($temp, $fileContent);
+
+        return 'image/svg+xml' === mime_content_type($temp);
+    }
+
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\Framework\Api\ImageContentValidatorInterface"
+                type="MageSuite\BrandManagement\Validator\ImageContentValidator" />
     <preference for="MageSuite\BrandManagement\Api\BrandsRepositoryInterface"
                 type="MageSuite\BrandManagement\Model\BrandsRepository" />
     <preference for="MageSuite\BrandManagement\Api\Data\BrandsInterface"

--- a/view/adminhtml/ui_component/brands_edit_form.xml
+++ b/view/adminhtml/ui_component/brands_edit_form.xml
@@ -165,23 +165,25 @@
                     <item name="sortOrder" xsi:type="number">30</item>
                 </item>
             </argument>
-            <field name="brand_icon">
-                <argument name="data" xsi:type="array">
-                    <item name="config" xsi:type="array">
-                        <item name="label" xsi:type="string" translate="true">Brand Icon</item>
-                        <item name="formElement" xsi:type="string">fileUploader</item>
-                        <item name="componentType" xsi:type="string">fileUploader</item>
-                        <item name="notice" xsi:type="string" translate="true">Allowed file types: png, gif, jpg, jpeg, svg. Max file size 1MB.</item>
-                        <item name="maxFileSize" xsi:type="number">1048576</item>
-                        <item name="allowedExtensions" xsi:type="string">jpg jpeg gif png svg</item>
-                        <item name="uploaderConfig" xsi:type="array">
-                            <item name="url" xsi:type="string">brands/brand/upload</item>
-                        </item>
-                        <item name="validation" xsi:type="array">
-                            <item name="required-entry" xsi:type="boolean">false</item>
-                        </item>
-                    </item>
-                </argument>
+            <field name="brand_icon" formElement="imageUploader">
+                <settings>
+                    <label translate="true">Brand Icon</label>
+                    <componentType>imageUploader</componentType>
+                    <validation>
+                        <rule name="required-entry" xsi:type="boolean">false</rule>
+                    </validation>
+                </settings>
+                <formElements>
+                    <imageUploader>
+                        <settings>
+                            <allowedExtensions>jpg jpeg gif png svg</allowedExtensions>
+                            <maxFileSize>1048576</maxFileSize>
+                            <uploaderConfig>
+                                <param xsi:type="string" name="url">brands/brand/upload</param>
+                            </uploaderConfig>
+                        </settings>
+                    </imageUploader>
+                </formElements>
             </field>
             <field name="use_config.brand_icon">
                 <argument name="data" xsi:type="array">
@@ -208,23 +210,25 @@
                     <item name="sortOrder" xsi:type="number">35</item>
                 </item>
             </argument>
-            <field name="brand_additional_icon">
-                <argument name="data" xsi:type="array">
-                    <item name="config" xsi:type="array">
-                        <item name="label" xsi:type="string" translate="true">Brand Additional Icon</item>
-                        <item name="formElement" xsi:type="string">fileUploader</item>
-                        <item name="componentType" xsi:type="string">fileUploader</item>
-                        <item name="notice" xsi:type="string" translate="true">Allowed file types: png, gif, jpg, jpeg, svg. Max file size 1MB.</item>
-                        <item name="maxFileSize" xsi:type="number">1048576</item>
-                        <item name="allowedExtensions" xsi:type="string">jpg jpeg gif png svg</item>
-                        <item name="uploaderConfig" xsi:type="array">
-                            <item name="url" xsi:type="string">brands/brand/upload</item>
-                        </item>
-                        <item name="validation" xsi:type="array">
-                            <item name="required-entry" xsi:type="boolean">false</item>
-                        </item>
-                    </item>
-                </argument>
+            <field name="brand_additional_icon" formElement="imageUploader">
+                <settings>
+                    <label translate="true">Brand Additional Icon</label>
+                    <componentType>imageUploader</componentType>
+                    <validation>
+                        <rule name="required-entry" xsi:type="boolean">false</rule>
+                    </validation>
+                </settings>
+                <formElements>
+                    <imageUploader>
+                        <settings>
+                            <allowedExtensions>jpg jpeg gif png svg</allowedExtensions>
+                            <maxFileSize>1048576</maxFileSize>
+                            <uploaderConfig>
+                                <param xsi:type="string" name="url">brands/brand/upload</param>
+                            </uploaderConfig>
+                        </settings>
+                    </imageUploader>
+                </formElements>
             </field>
             <field name="use_config.brand_additional_icon">
                 <argument name="data" xsi:type="array">


### PR DESCRIPTION
Problem with ImageContentValidator #5 

```
            $imageProperties = @getimagesizefromstring($fileContent);
            if (empty($imageProperties)) {
                throw new InputException(new Phrase('The image content must be valid base64 encoded data.'));
            }
            $sourceMimeType = $imageProperties['mime'];
```

getimagesizefromstring () returns null for .svg images
just wrap this method with the isSvg () method and we can load .svg images via the API

Need more refactor, but now it works without problems